### PR TITLE
Add SQLite persistence and migrate activities

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -10,6 +10,9 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
 import os
 from pathlib import Path
+import json
+
+import db
 
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
@@ -19,63 +22,69 @@ current_dir = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
 
-# In-memory activity database
-activities = {
+# Seed activities (migrated from the previous in-memory store)
+seed_activities = {
     "Chess Club": {
         "description": "Learn strategies and compete in chess tournaments",
         "schedule": "Fridays, 3:30 PM - 5:00 PM",
         "max_participants": 12,
-        "participants": ["michael@mergington.edu", "daniel@mergington.edu"]
+        "participants": ["michael@mergington.edu", "daniel@mergington.edu"],
     },
     "Programming Class": {
         "description": "Learn programming fundamentals and build software projects",
         "schedule": "Tuesdays and Thursdays, 3:30 PM - 4:30 PM",
         "max_participants": 20,
-        "participants": ["emma@mergington.edu", "sophia@mergington.edu"]
+        "participants": ["emma@mergington.edu", "sophia@mergington.edu"],
     },
     "Gym Class": {
         "description": "Physical education and sports activities",
         "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
         "max_participants": 30,
-        "participants": ["john@mergington.edu", "olivia@mergington.edu"]
+        "participants": ["john@mergington.edu", "olivia@mergington.edu"],
     },
     "Soccer Team": {
         "description": "Join the school soccer team and compete in matches",
         "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",
         "max_participants": 22,
-        "participants": ["liam@mergington.edu", "noah@mergington.edu"]
+        "participants": ["liam@mergington.edu", "noah@mergington.edu"],
     },
     "Basketball Team": {
         "description": "Practice and play basketball with the school team",
         "schedule": "Wednesdays and Fridays, 3:30 PM - 5:00 PM",
         "max_participants": 15,
-        "participants": ["ava@mergington.edu", "mia@mergington.edu"]
+        "participants": ["ava@mergington.edu", "mia@mergington.edu"],
     },
     "Art Club": {
         "description": "Explore your creativity through painting and drawing",
         "schedule": "Thursdays, 3:30 PM - 5:00 PM",
         "max_participants": 15,
-        "participants": ["amelia@mergington.edu", "harper@mergington.edu"]
+        "participants": ["amelia@mergington.edu", "harper@mergington.edu"],
     },
     "Drama Club": {
         "description": "Act, direct, and produce plays and performances",
         "schedule": "Mondays and Wednesdays, 4:00 PM - 5:30 PM",
         "max_participants": 20,
-        "participants": ["ella@mergington.edu", "scarlett@mergington.edu"]
+        "participants": ["ella@mergington.edu", "scarlett@mergington.edu"],
     },
     "Math Club": {
         "description": "Solve challenging problems and participate in math competitions",
         "schedule": "Tuesdays, 3:30 PM - 4:30 PM",
         "max_participants": 10,
-        "participants": ["james@mergington.edu", "benjamin@mergington.edu"]
+        "participants": ["james@mergington.edu", "benjamin@mergington.edu"],
     },
     "Debate Team": {
         "description": "Develop public speaking and argumentation skills",
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
-        "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
-    }
+        "participants": ["charlotte@mergington.edu", "henry@mergington.edu"],
+    },
 }
+
+
+@app.on_event("startup")
+def startup_event():
+    # initialize sqlite DB and seed activities (if no data present)
+    db.init_db(seed_activities)
 
 
 @app.get("/")
@@ -85,48 +94,23 @@ def root():
 
 @app.get("/activities")
 def get_activities():
-    return activities
+    return db.get_activities()
 
 
 @app.post("/activities/{activity_name}/signup")
 def signup_for_activity(activity_name: str, email: str):
     """Sign up a student for an activity"""
-    # Validate activity exists
-    if activity_name not in activities:
-        raise HTTPException(status_code=404, detail="Activity not found")
-
-    # Get the specific activity
-    activity = activities[activity_name]
-
-    # Validate student is not already signed up
-    if email in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is already signed up"
-        )
-
-    # Add student
-    activity["participants"].append(email)
-    return {"message": f"Signed up {email} for {activity_name}"}
+    success, msg = db.signup(activity_name, email)
+    if not success:
+        # db.signup returns (False, "reason") when something is wrong
+        raise HTTPException(status_code=400, detail=msg)
+    return {"message": msg}
 
 
 @app.delete("/activities/{activity_name}/unregister")
 def unregister_from_activity(activity_name: str, email: str):
     """Unregister a student from an activity"""
-    # Validate activity exists
-    if activity_name not in activities:
-        raise HTTPException(status_code=404, detail="Activity not found")
-
-    # Get the specific activity
-    activity = activities[activity_name]
-
-    # Validate student is signed up
-    if email not in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is not signed up for this activity"
-        )
-
-    # Remove student
-    activity["participants"].remove(email)
-    return {"message": f"Unregistered {email} from {activity_name}"}
+    success, msg = db.unregister(activity_name, email)
+    if not success:
+        raise HTTPException(status_code=400, detail=msg)
+    return {"message": msg}

--- a/src/db.py
+++ b/src/db.py
@@ -1,0 +1,104 @@
+import sqlite3
+from pathlib import Path
+import json
+from typing import Dict, Any
+
+DB_PATH = Path(__file__).parent / "data.sqlite3"
+
+
+def init_db(seed_activities: Dict[str, Any]):
+    """Create tables if they don't exist and seed activities if empty."""
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.cursor()
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS activities (
+            name TEXT PRIMARY KEY,
+            description TEXT,
+            schedule TEXT,
+            max_participants INTEGER,
+            participants TEXT
+        )
+        """
+    )
+    # if table empty, insert seed activities
+    cur.execute("SELECT COUNT(1) FROM activities")
+    cnt = cur.fetchone()[0]
+    if cnt == 0:
+        for name, v in seed_activities.items():
+            participants_json = json.dumps(v.get("participants", []))
+            cur.execute(
+                "INSERT INTO activities (name, description, schedule, max_participants, participants) VALUES (?, ?, ?, ?, ?)",
+                (name, v.get("description"), v.get("schedule"), v.get("max_participants", 0), participants_json),
+            )
+    conn.commit()
+    conn.close()
+
+
+def _connect():
+    conn = sqlite3.connect(DB_PATH)
+    return conn
+
+
+def get_activities():
+    conn = _connect()
+    cur = conn.cursor()
+    cur.execute("SELECT name, description, schedule, max_participants, participants FROM activities")
+    rows = cur.fetchall()
+    conn.close()
+    activities = {}
+    for name, description, schedule, max_participants, participants in rows:
+        try:
+            parts = json.loads(participants) if participants else []
+        except Exception:
+            parts = []
+        activities[name] = {
+            "description": description,
+            "schedule": schedule,
+            "max_participants": max_participants,
+            "participants": parts,
+        }
+    return activities
+
+
+def signup(activity_name: str, email: str):
+    conn = _connect()
+    cur = conn.cursor()
+    cur.execute("SELECT participants, max_participants FROM activities WHERE name = ?", (activity_name,))
+    row = cur.fetchone()
+    if not row:
+        conn.close()
+        return False, "Activity not found"
+    participants_json, max_participants = row
+    participants = json.loads(participants_json) if participants_json else []
+    if email in participants:
+        conn.close()
+        return False, "Student is already signed up"
+    if max_participants and len(participants) >= max_participants:
+        conn.close()
+        return False, "No spots left"
+    participants.append(email)
+    cur.execute("UPDATE activities SET participants = ? WHERE name = ?", (json.dumps(participants), activity_name))
+    conn.commit()
+    conn.close()
+    return True, f"Signed up {email} for {activity_name}"
+
+
+def unregister(activity_name: str, email: str):
+    conn = _connect()
+    cur = conn.cursor()
+    cur.execute("SELECT participants FROM activities WHERE name = ?", (activity_name,))
+    row = cur.fetchone()
+    if not row:
+        conn.close()
+        return False, "Activity not found"
+    participants_json = row[0]
+    participants = json.loads(participants_json) if participants_json else []
+    if email not in participants:
+        conn.close()
+        return False, "Student is not signed up for this activity"
+    participants.remove(email)
+    cur.execute("UPDATE activities SET participants = ? WHERE name = ?", (json.dumps(participants), activity_name))
+    conn.commit()
+    conn.close()
+    return True, f"Unregistered {email} from {activity_name}"


### PR DESCRIPTION
This PR adds a small SQLite-backed persistence layer for activities and migrates the existing in-memory activities into the DB on startup.

Files changed:
- src/db.py: new helper module for SQLite storage and basic CRUD (get, signup, unregister)
- src/app.py: replaced in-memory store with DB-backed calls and added DB initialization on startup

Notes:
- The DB file is created at runtime at src/data.sqlite3
- No external dependencies were added (uses stdlib sqlite3)
- Next steps: add tests and update CI to validate DB-backed behavior
